### PR TITLE
Removed `PrefixLength` from static IPv6 usage

### DIFF
--- a/HWMgmt/OCPBaselineRedfishService.v1_0_0.json
+++ b/HWMgmt/OCPBaselineRedfishService.v1_0_0.json
@@ -152,10 +152,6 @@
                         "Address": {
                             "ReadRequirement": "Mandatory",
                             "WriteRequirement": "Mandatory"
-                        },
-                        "PrefixLength": {
-                            "ReadRequirement": "Mandatory",
-                            "WriteRequirement": "Mandatory"
                         }
                     }
                 },
@@ -163,10 +159,6 @@
                     "ReadRequirement": "Recommended",
                     "PropertyRequirements": {
                         "Address": {
-                            "ReadRequirement": "Mandatory",
-                            "WriteRequirement": "Mandatory"
-                        },
-                        "PrefixLength": {
                             "ReadRequirement": "Mandatory",
                             "WriteRequirement": "Mandatory"
                         }


### PR DESCRIPTION
Prefix length is not needed when a static address is specified, the requirement was simply copied from the more general IPv6 property requirements.

Fix #96 