### PR TITLE
Fix: use ParameterValues instead of MinSupportValues in ActionRequire…

### DIFF
--- a/HWMgmt/OCPBaselineHardwareManagement.v1_1_0.json
+++ b/HWMgmt/OCPBaselineHardwareManagement.v1_1_0.json
@@ -293,7 +293,7 @@
 					"Reset": {
 						"Parameters": {
 							"ResetType": {
-								"MinSupportValues": ["ForceRestart"]
+								"ParameterValues": ["ForceRestart"]
 							}
 						}
 					}


### PR DESCRIPTION
MinSupportValues is only valid for property-level functions per the Redfish spec: https://www.dmtf.org/sites/default/files/standards/documents/DSP0272_1.8.0.pdf. Updated ActionRequirements parameters to use ParameterValues.

---
This is unrelated to the above change, but I noticed the current profiles are based on v1.0.0 of the Redfish profile schema. I am using v1.8.0, and the profiles do not pass schema validation. Are there plans to update the profiles in this repository to be  based on v1.8.0?